### PR TITLE
Michiel's review of #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ HOST='solid.local' PORT=8080 composer serve
 This command can also be run through a docker container, for instance:
 
 ```
-PORT=8080               \
+export PORT=8080 &&     \
 docker run              \
    --env "PORT=${PORT}" \
    --expose "${PORT}"   \

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ to wherever it will be hosted by the Docker container.
 For instance:
 
 ```
-PORT=80                    \
+export PORT=80 &&          \
 docker run                 \
    --env "PORT=${PORT}"    \
    --expose "${PORT}"      \


### PR DESCRIPTION
I think doing `VAR=x ./binary` makes that variable available to ./binary as it executes, but it does not make it available to the rest of the line. So you would either need to do what I did here, or if you prefer, this also works (but I don't know how to do it without needing a backslash there):
```sh
PORT=80 bash -c "echo \${PORT}"
```